### PR TITLE
Eng 196: Ability for Engine to train different performance type models

### DIFF
--- a/src/py/config/constants.py
+++ b/src/py/config/constants.py
@@ -39,11 +39,38 @@ GPU_JOBS = [IMAGE_CLASSIFICATION_TEST_JOB_NAME, IMAGE_CLASSIFICATION_TRAINING_JO
 # Database Constants
 NUM_INSTANCES = 'NUM_INSTANCES'
 
+# Map for our image classification model names to a EfficientNetV2 model
+IC_MODEL_TYPE_TO_EFFICIENTNET_MAP = {
+    'extra_small': 'efficientnetv2-b0',
+    'small': 'efficientnetv2-b3',
+    'medium': 'efficientnetv2-s',
+    'large': 'efficientnetv2-m',
+    'extra-large': 'efficientnetv2-l'
+}
+
 
 # Model Statuses
+
 class AutoNameEnum(Enum):
     def _generate_next_value_(name: str, start: int, count: int, last_values: List[Any]) -> Any:
         return name
+
+
+class AutoNameLowercaseHyphenatedSpace(Enum):
+    def _generate_next_value_(name: str, start: int, count: int, last_values: List[Any]) -> Any:
+        return name.lower().replace('_', '-')
+
+
+class ModelType(AutoNameLowercaseHyphenatedSpace):
+    """Enum that contains different image classification model types"""
+    EXTRA_SMALL = auto()
+    SMALL = auto()
+    MEDIUM = auto()
+    LARGE = auto()
+    EXTRA_LARGE = auto()
+
+
+POSSIBLE_MODEL_TYPES = set([model_type.value for model_type in ModelType])
 
 
 class ModelExportType(AutoNameEnum):
@@ -52,7 +79,7 @@ class ModelExportType(AutoNameEnum):
     LITE = auto()
 
 
-POSSIBLE_MODEL_EXPORT_TYPES = [export_type.value for export_type in ModelExportType]
+POSSIBLE_MODEL_EXPORT_TYPES = set([export_type.value for export_type in ModelExportType])
 
 
 class ModelLabellingType(AutoNameEnum):
@@ -60,7 +87,7 @@ class ModelLabellingType(AutoNameEnum):
     SINGLE_LABEL = auto()
 
 
-POSSIBLE_MODEL_LABELLING_TYPES = [export_type.value for export_type in ModelLabellingType]
+POSSIBLE_MODEL_LABELLING_TYPES = set([export_type.value for export_type in ModelLabellingType])
 
 
 class ModelExportStatus(AutoNameEnum):

--- a/src/py/main.py
+++ b/src/py/main.py
@@ -13,7 +13,7 @@ from werkzeug.utils import secure_filename
 
 from config import config
 from config import constants
-from config.constants import ModelStatus, POSSIBLE_MODEL_EXPORT_TYPES, POSSIBLE_MODEL_LABELLING_TYPES
+from config.constants import ModelStatus, POSSIBLE_MODEL_EXPORT_TYPES, POSSIBLE_MODEL_LABELLING_TYPES, POSSIBLE_MODEL_TYPES
 from dataset.jobs.create_dataset_job import CreateDatasetJob
 from dataset.jobs.delete_all_inputs_from_dataset_job import DeleteAllInputsFromDatasetJob
 from dataset.jobs.delete_dataset_job import DeleteDatasetJob
@@ -159,7 +159,9 @@ def create_model_route():
     if error_obj is not None:
         return {'Error': error_obj}, 400
     if req_data['labelling_type'] not in POSSIBLE_MODEL_LABELLING_TYPES:
-        return {'Error': f"Labelling type: '{req_data['labelling_type']}' an is invalid labelling type"}, 400
+        return {'Error': f"Labelling type: '{req_data['labelling_type']}' is an invalid labelling type"}, 400
+    if req_data['model_type_extra'] not in POSSIBLE_MODEL_TYPES:
+        return {'Error': f"Model Type: '{req_data['model_type_extra']}' is an invalid image classification model type"}, 400
     # Check to see if model already exists
     if os.path.isdir(config.MODEL_DIR / req_data['model_name']):
         return {'Error': 'Model already exists'}, 400

--- a/src/py/model_config/jobs/create_model_job.py
+++ b/src/py/model_config/jobs/create_model_job.py
@@ -27,12 +27,5 @@ class ModelCreationJob(BaseJob):
         super().set_status('Initializing Model Settings')
         super().set_progress(1)
         update_job(self)
-        # Create settings.json with model_config
-        with open(config.MODEL_DIR / model_config["model_name"] / 'model_settings.json', 'w', encoding='utf-8') as f:
-            json.dump(model_config, f, ensure_ascii=False, indent=4, sort_keys=True)
-        # Windows only
-        # Mark file as hidden and read-only to 'help' prevent accidental overwrites
-        args = ['attrib', '+r', '+h', (config.MODEL_DIR / model_config['model_name'] / 'model_settings.json').absolute()]
-        subprocess.check_call(args)
         super().set_progress(2)
         super().clean_up_job()

--- a/src/py/model_config/jobs/delete_model_job.py
+++ b/src/py/model_config/jobs/delete_model_job.py
@@ -1,4 +1,6 @@
+import os
 import shutil
+import stat
 
 from overrides import overrides
 
@@ -6,6 +8,13 @@ from config import config
 from db.commands.job_commands import update_job
 from db.commands.model_commands import delete_model
 from job.base_job import BaseJob
+from log.logger import log
+
+
+def del_rw(action, name, exc):
+    """shutil.rmtree backup onerror function that removes a directory the slower way"""
+    os.chmod(name, stat.S_IWRITE)
+    os.remove(name)
 
 
 class ModelDeletionJob(BaseJob):
@@ -18,7 +27,8 @@ class ModelDeletionJob(BaseJob):
         super().run()
         model = self.arg
         model_dir = config.MODEL_DIR / model['model_name']
-        shutil.rmtree(model_dir, ignore_errors=True)
+        log(model_dir.absolute())
+        shutil.rmtree(str(model_dir.absolute()), ignore_errors=False, onerror=del_rw)
         super().set_status("Updating DB")
         super().set_progress(1)
         update_job(self)

--- a/src/py/train/jobs/train_ic_job.py
+++ b/src/py/train/jobs/train_ic_job.py
@@ -82,6 +82,7 @@ class TrainImageClassifierJob(BaseJob):
             'model_cache_path': c.MODEL_CACHE,
             'model_dir': c.MODEL_DIR,
             'model_name': model['model_name'],
+            'model_type': model['model_type_extra'],
             'current_extra_data': self.extra_data()
         }
 
@@ -138,12 +139,13 @@ def update_local_extra_data(data_to_update: dict, extra_data: dict, file: tf.io.
 
 
 def train_in_separate_process(queue: Queue):
-    job_id, num_classes, inputs, model_cache_path, model_dir, model_name, current_extra_data = itemgetter('job_id',
-                                                                                                          'num_classes', 'inputs',
-                                                                                                          'model_cache_path',
-                                                                                                          'model_dir',
-                                                                                                          'model_name',
-                                                                                                          'current_extra_data')(
+    job_id, num_classes, inputs, model_cache_path, model_dir, model_name, model_type, current_extra_data = itemgetter('job_id',
+                                                                                                                      'num_classes', 'inputs',
+                                                                                                                      'model_cache_path',
+                                                                                                                      'model_dir',
+                                                                                                                      'model_name',
+                                                                                                                      'model_type',
+                                                                                                                      'current_extra_data')(
         queue.get())
 
     job_updater_json_filepath: Path = model_dir / model_name / c.MODEL_TRAINING_TIME_EXTRA_DATA_NAME
@@ -155,7 +157,7 @@ def train_in_separate_process(queue: Queue):
     interpolation = tf.image.ResizeMethod.BILINEAR
     IMAGE_SIZE = (224, 224)
     BATCH_SIZE = 32
-    effnet_model_name = 'efficientnetv2-b0'
+    effnet_model_name = constants.IC_MODEL_TYPE_TO_EFFICIENTNET_MAP[model_type]
     TRAIN_SPLIT = 0.8
     current_extra_data = dict(current_extra_data)
     extra_data_file = tf.io.gfile.GFile(job_updater_json_filepath.absolute(), 'w')

--- a/src/renderer/view/components/model-selection/content/image_classification/ICModelContent.tsx
+++ b/src/renderer/view/components/model-selection/content/image_classification/ICModelContent.tsx
@@ -50,13 +50,16 @@ const ICModelContentC = React.memo((props: Props) => {
 
 	// Radio Card - Model Type
 
-	const modelTypeRadioOptions = ['Fast', 'Balanced', 'Precise'];
+	const modelTypeRadioOptions = ['Extra Small', 'Small', 'Medium', 'Large', 'Extra Large'];
 	const modelTypeRadioDescriptions = [
-		'A model that is more focused on being smaller and faster at the cost of being less accurate.',
-		'A model that is both relatively fast and fairly accurate.',
-		"A model that is more focused on it's accuracy at the cost of being slower and larger",
+		'Extremely lightweight model, extremely fast more innacurate. Best suited for mobile and edge devices.',
+		'Lightweight model, fast but slightly innacurate. Best suited for low-latency real-time requirements.',
+		'Balanced model both relatively fast and accurate. Best suited for all requirements.',
+		'Large model, accurate but slow. Best suited for high-accuracy requirements.',
+		'Extremely large model, extremely accurate but very slow. Best suited for accuracy-critical requirements.',
 	];
-	const [modelTypeValue, setModelTypeValue] = useState(modelTypeRadioOptions[1]);
+
+	const [modelTypeValue, setModelTypeValue] = useState(modelTypeRadioOptions[2]);
 
 	const { getRootProps: getModelTypeRootProps, getRadioProps: getModelTypeRadioProps } = useRadioGroup({
 		name: 'modelType',
@@ -154,7 +157,7 @@ const ICModelContentC = React.memo((props: Props) => {
 		const [createModelErr, createModelRes] = await EngineRequestHandler.getInstance().createModel({
 			model_name: modelNameValue,
 			model_type: 'image_classification',
-			model_type_extra: modelTypeValue.toLowerCase(),
+			model_type_extra: modelTypeValue.toLowerCase().replace(/\s+/g, '-'),
 			labelling_type: getLabellingTypeForEngine(labellingType),
 		});
 		// If error occurred when sending the Engine Action

--- a/src/renderer/view/components/model-selection/content/image_classification/ICModelRadio.tsx
+++ b/src/renderer/view/components/model-selection/content/image_classification/ICModelRadio.tsx
@@ -23,7 +23,7 @@ export const ICModelRadioCard = React.memo((props: Props) => {
 	const borderColor = mode('thia.gray.200', 'thia.gray.600');
 
 	return (
-		<Box as='label' position='relative' w='250px' rounded='sm'>
+		<Box as='label' position='relative' w='275px' rounded='sm'>
 			<input
 				{...input}
 				onClick={(e) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const lodash = require('lodash');
 const CopyPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-
+const webpack = require('webpack');
 const path = require('path');
 
 function srcPaths(...srcs) {
@@ -91,7 +91,7 @@ const commonConfig = {
 	experiments: {
 		topLevelAwait: true,
 	},
-	plugins: [new ForkTsCheckerWebpackPlugin()],
+	plugins: [new ForkTsCheckerWebpackPlugin(), new webpack.WatchIgnorePlugin({ paths: [srcPaths('src', 'py')] })],
 };
 // #endregion
 


### PR DESCRIPTION
### Extra Fixes
- Webpack watch doesn't watch **Engine** code now as there was an error with `npm run dev` failing due to **Engine**'s `engine.db` sqlite database file not allowing it to be watched.
- Fixed issue of model not deleting a model directory due to `model_settings.json` being a hidden file by adding an onerror function to `shutil.rmtree` that deletes the directory in a slower way.
- Removed the creation of `model_settings.json` as the only source of truth should be **Engine**'s database.