### PR TITLE
Eng 193: Fixed errors when routing to non-existent dataset/model page

### DIFF
--- a/src/renderer/view/components/datasets/preview/input/PaginationCell.tsx
+++ b/src/renderer/view/components/datasets/preview/input/PaginationCell.tsx
@@ -28,7 +28,7 @@ const PaginationCellC = React.memo(
 		const [isSelectedCell, setIsSelectedCell] = useState(false);
 		const [label, setLabel] = useState<Label>(nullLabel);
 		const [imageLoaded, imageSrc] = useProgressiveImage(`${ENGINE_URL}/dataset/${datasetID}/input/${input.id}`, {
-			readyToLoad: datasetID!.length > 0 && input !== undefined && input.id !== undefined && input.id.length > 0,
+			readyToLoad: datasetID!.length > 0 && input.id.length > 0,
 		});
 		const brightness = mode('15%', '10%');
 

--- a/src/renderer/view/components/datasets/preview/input/PaginationCell.tsx
+++ b/src/renderer/view/components/datasets/preview/input/PaginationCell.tsx
@@ -28,7 +28,7 @@ const PaginationCellC = React.memo(
 		const [isSelectedCell, setIsSelectedCell] = useState(false);
 		const [label, setLabel] = useState<Label>(nullLabel);
 		const [imageLoaded, imageSrc] = useProgressiveImage(`${ENGINE_URL}/dataset/${datasetID}/input/${input.id}`, {
-			readyToLoad: datasetID!.length > 0 && input.id.length > 0,
+			readyToLoad: datasetID!.length > 0 && input !== undefined && input.id !== undefined && input.id.length > 0,
 		});
 		const brightness = mode('15%', '10%');
 

--- a/src/renderer/view/components/error-boundaries/ErrorBoundaryReplace.tsx
+++ b/src/renderer/view/components/error-boundaries/ErrorBoundaryReplace.tsx
@@ -1,0 +1,45 @@
+import { chakra } from '@chakra-ui/react';
+import { Replace, replace } from 'connected-react-router';
+import React from 'react';
+import { connect } from 'react-redux';
+
+interface Props {
+	replace: Replace;
+	replacePath: string;
+}
+
+interface State {
+	hasError: boolean;
+}
+class ErrorBoundaryReplace extends React.Component<Props, State> {
+	constructor(props) {
+		super(props);
+		this.state = { hasError: false };
+	}
+
+	static getDerivedStateFromError() {
+		// Update state so the next render will show the fallback UI.
+		return { hasError: true };
+	}
+
+	componentDidCatch() {
+		// You can also log the error to an error reporting service
+		//   logErrorToMyService(error, errorInfo);
+		const { replace, replacePath } = this.props;
+		replace(replacePath);
+	}
+
+	render() {
+		const { children } = this.props;
+		const { hasError } = this.state;
+
+		if (hasError) {
+			return <chakra.h1>Uh oh</chakra.h1>;
+		}
+		return children;
+	}
+}
+
+export default connect(null, {
+	replace,
+})(ErrorBoundaryReplace);

--- a/src/renderer/view/pages/Dataset.tsx
+++ b/src/renderer/view/pages/Dataset.tsx
@@ -24,13 +24,18 @@ import { changeActiveDataset } from '_/renderer/state/active-dataset-page/Active
 import { IChangeActiveDatasetAction } from '_/renderer/state/active-dataset-page/model/actionTypes';
 import { IActiveDatasetReducer } from '_/renderer/state/active-dataset-page/model/reducerTypes';
 import { useVerticalScrollbar } from '_/renderer/view/helpers/hooks/scrollbar';
+import { changeSelectedPageAction } from '_/renderer/state/side-menu/SideModelAction';
+import { MODELS_PAGE } from '../helpers/constants/pageConstants';
+import { IChangeSelectedPageAction } from '_/renderer/state/side-menu/model/actionTypes';
+import ErrorBoundaryReplace from '../components/error-boundaries/ErrorBoundaryReplace';
 
 interface Props {
 	activeDataset: IActiveDatasetReducer;
 	changeActiveDataset: (activeDataset: Dataset, labels: Labels) => IChangeActiveDatasetAction;
+	changeSelectedPage: (pageNumber: number) => IChangeSelectedPageAction;
 }
 
-const DatasetPage = React.memo(({ activeDataset, changeActiveDataset }: Props) => {
+const DatasetPage = React.memo(({ activeDataset, changeActiveDataset, changeSelectedPage }: Props) => {
 	const datasetID = useRouteMatch().params['id'];
 	// const [dataset, setDataset] = useState<Dataset | undefined>(undefined);
 
@@ -50,6 +55,7 @@ const DatasetPage = React.memo(({ activeDataset, changeActiveDataset }: Props) =
 	}, [datasetID]);
 
 	useEffect(() => {
+		changeSelectedPage(MODELS_PAGE);
 		refreshDataset();
 	}, []);
 
@@ -104,7 +110,9 @@ const DatasetPage = React.memo(({ activeDataset, changeActiveDataset }: Props) =
 						Select images to transfer to dataset
 					</Text>
 				</Box>
-				<DragNDrop refreshDataset={refreshDataset} />
+				<ErrorBoundaryReplace replacePath='/models'>
+					<DragNDrop refreshDataset={refreshDataset} />
+				</ErrorBoundaryReplace>
 			</Box>
 			<Spacer />
 		</VStack>
@@ -119,4 +127,5 @@ const mapStateToProps = (state: IAppState) => ({
 
 export default connect(mapStateToProps, {
 	changeActiveDataset,
+	changeSelectedPage: changeSelectedPageAction,
 })(DatasetPage);

--- a/src/renderer/view/pages/LandingPage.tsx
+++ b/src/renderer/view/pages/LandingPage.tsx
@@ -83,13 +83,11 @@ const LandingPage = () => {
 				animate={{ opacity: 1, scale: 1, y: '0%' }}
 				transition={{ transition: 'ease', duration: 1 }}>
 				<Box>
-					<VStack spacing={6} pt={12} px={{ base: 0, xl: 20 }}>
+					<VStack spacing={4} pt={12} px={{ base: 0, xl: 20 }}>
 						<Heading px={10} fontSize={{ base: '3xl', md: '5xl' }} lineHeight='shorter' textAlign='center'>
 							AutoML ran within your ecosystem
 						</Heading>
-						<Button mt='3' colorScheme='thia.purple' onClick={showLoginWindow}>
-							Get Started
-						</Button>
+
 						<Box display='block' rounded='xl'>
 							<Center w='full' h='full' pb='20px'>
 								<chakra.img
@@ -99,6 +97,9 @@ const LandingPage = () => {
 								/>
 							</Center>
 						</Box>
+						<Button mt='3' colorScheme='thia.purple' onClick={showLoginWindow}>
+							Get Started
+						</Button>
 					</VStack>
 				</Box>
 			</motion.div>

--- a/src/renderer/view/pages/Model.tsx
+++ b/src/renderer/view/pages/Model.tsx
@@ -40,13 +40,15 @@ import { changeSelectedPageAction } from '_/renderer/state/side-menu/SideModelAc
 import { IChangeSelectedPageAction } from '_/renderer/state/side-menu/model/actionTypes';
 import { MODELS_PAGE } from '../helpers/constants/pageConstants';
 import { toast } from '../helpers/functionHelpers';
+import { Replace, replace } from 'connected-react-router';
 
 interface Props {
 	selectedDatasetID: ISelectedDatasetReducer;
 	resetSelectedDataset: () => IResetSelectedDatasetAction;
 	changeSelectedPage: (pageNumber: number) => IChangeSelectedPageAction;
+	replace: Replace;
 }
-const ModelPage = React.memo(({ selectedDatasetID, resetSelectedDataset, changeSelectedPage }: Props) => {
+const ModelPage = React.memo(({ selectedDatasetID, resetSelectedDataset, changeSelectedPage, replace }: Props) => {
 	const modelID = useRouteMatch().params['id'];
 	const [dataLoaded, setDataLoaded] = useState(false);
 	const [model, setModel] = useState<ModelPage>(nullModel);
@@ -65,8 +67,11 @@ const ModelPage = React.memo(({ selectedDatasetID, resetSelectedDataset, changeS
 		const [error, resData] = await EngineRequestHandler.getInstance().getModel(modelID);
 		if (!error) {
 			setModel(resData);
+			setDataLoaded(true);
+		} else {
+			// Failed to get model, route back to models page
+			replace('/models');
 		}
-		setDataLoaded(true);
 	};
 
 	useEffect(() => {
@@ -217,4 +222,5 @@ const mapStateToProps = (state: IAppState) => ({
 export default connect(mapStateToProps, {
 	resetSelectedDataset: resetSelectedDatasetAction,
 	changeSelectedPage: changeSelectedPageAction,
+	replace,
 })(ModelPage);


### PR DESCRIPTION
Using error boundaries for dataset page as there is an irrecoverable error that is thrown in `PaginationCell` when given invalid dataset id to the dataset page, so it is easier to use error boundaries.